### PR TITLE
Use id from opts so multiple drainers can be used

### DIFF
--- a/lib/ranch_connection_drainer.ex
+++ b/lib/ranch_connection_drainer.ex
@@ -22,11 +22,12 @@ defmodule RanchConnectionDrainer do
 
   @spec child_spec(options :: keyword()) :: Supervisor.child_spec()
   def child_spec(options) when is_list(options) do
+    id = Keyword.fetch(options, :id, __MODULE__)
     ranch_ref = Keyword.fetch!(options, :ranch_ref)
     shutdown = Keyword.fetch!(options, :shutdown)
 
     %{
-      id: __MODULE__,
+      id: id,
       start: {__MODULE__, :start_link, [ranch_ref]},
       shutdown: shutdown
     }


### PR DESCRIPTION
I was testing this lib with a service that we have with two endpoints.
Since the child_spec id is always __MODULE__, we couldn't start one drainer for each endpoint.

This should do the trick.

Thank you 🙇 